### PR TITLE
fix: eslintConfig and eslintIgnore being skipped

### DIFF
--- a/packages/ez-scripts/CHANGELOG.md
+++ b/packages/ez-scripts/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+### Fixed
+- Fix `eslintConfig` and `eslintIgnore` not being used for lint command

--- a/packages/ez-scripts/jest.config.js
+++ b/packages/ez-scripts/jest.config.js
@@ -1,0 +1,8 @@
+// @ts-check
+/** @type {import('@jest/types').Config.InitialOptions} */
+module.exports = {
+  name: 'ez-scripts',
+  displayName: 'ez-scripts',
+  roots: ['<rootDir>/src'],
+  resetMocks: true,
+};

--- a/packages/ez-scripts/package.json
+++ b/packages/ez-scripts/package.json
@@ -20,7 +20,6 @@
     "cross-spawn": "^7.0.0",
     "eslint-config-ezcater-typescript": "^4.0.0",
     "eslint": "^7.13.0",
-    "lodash.has": "^4.5.2",
     "prettier": "^2.1.2",
     "read-pkg-up": "^7.0.0",
     "typescript": "^4.0.5",

--- a/packages/ez-scripts/src/__tests__/utils.test.js
+++ b/packages/ez-scripts/src/__tests__/utils.test.js
@@ -1,0 +1,44 @@
+// @ts-check
+describe('utils', () => {
+  beforeEach(() => {
+    jest.resetModules();
+  });
+
+  afterAll(() => {
+    jest.resetModules();
+  });
+
+  describe('hasPkgProp', () => {
+    describe('when prop exists in package.json', () => {
+      it('returns true', () => {
+        const readPkgUp = require('read-pkg-up');
+        jest.spyOn(readPkgUp, 'sync').mockReturnValue({
+          packageJson: {
+            dependencies: {},
+            eslintConfig: {plugins: ['react']},
+          },
+          path: '/',
+        });
+        const utils = require('../utils');
+
+        expect(utils.hasPkgProp('eslintConfig')).toBe(true);
+      });
+    });
+
+    describe('when prop does not exist in package.json', () => {
+      it('returns false', () => {
+        const readPkgUp = require('read-pkg-up');
+        jest.spyOn(readPkgUp, 'sync').mockReturnValue({
+          packageJson: {
+            dependencies: {},
+            eslintIgnore: [],
+          },
+          path: '/',
+        });
+        const utils = require('../utils');
+
+        expect(utils.hasPkgProp('eslintConfig')).toBe(false);
+      });
+    });
+  });
+});

--- a/packages/ez-scripts/src/scripts/__tests__/lint.test.js
+++ b/packages/ez-scripts/src/scripts/__tests__/lint.test.js
@@ -1,0 +1,149 @@
+// @ts-check
+const originalArgv = process.argv;
+
+/** @param {Partial<ReturnType<import('cross-spawn')['sync']>>} [syncResult] */
+const buildMockCrossSpawn = syncResult => {
+  const crossSpawn = require('cross-spawn');
+  jest.spyOn(crossSpawn, 'sync').mockReturnValue({
+    output: [],
+    pid: 1234,
+    signal: null,
+    status: 1,
+    stderr: '',
+    stdout: '',
+    ...syncResult,
+  });
+
+  return crossSpawn;
+};
+
+/**
+ * @param {Object} [props]
+ * @param {string[]} [props.argv]
+ */
+const executeScript = (props = {}) => {
+  process.argv = props.argv || [];
+  require('../lint');
+};
+
+describe('lint', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    jest.spyOn(process, 'exit').mockImplementation();
+  });
+
+  afterEach(() => {
+    process.argv = originalArgv;
+  });
+
+  afterAll(() => {
+    jest.resetModules();
+  });
+
+  it('uses eslint with default args', () => {
+    const readPkgUp = require('read-pkg-up');
+    const crossSpawn = buildMockCrossSpawn();
+    jest.spyOn(readPkgUp, 'sync').mockReturnValue({
+      packageJson: {dependencies: {}},
+      path: '/',
+    });
+    executeScript();
+
+    expect(crossSpawn.sync).toHaveBeenCalledTimes(1);
+    expect(crossSpawn.sync).toHaveBeenCalledWith(
+      'eslint',
+      [
+        '--config',
+        './packages/ez-scripts/src/files/eslintrc.js',
+        '--ignore-path',
+        './packages/ez-scripts/src/files/.eslintignore',
+        '--cache',
+        '.',
+        '--ext',
+        'js,jsx,ts,tsx',
+      ],
+      {stdio: 'inherit'}
+    );
+  });
+
+  describe('with package.json prop "eslintConfig"', () => {
+    it('does not use ez-scripts eslint config', () => {
+      const readPkgUp = require('read-pkg-up');
+      const crossSpawn = buildMockCrossSpawn();
+      jest.spyOn(readPkgUp, 'sync').mockReturnValue({
+        packageJson: {
+          dependencies: {},
+          eslintConfig: {'no-console': 'off'},
+        },
+        path: '/',
+      });
+      executeScript();
+
+      expect(crossSpawn.sync).toHaveBeenCalledTimes(1);
+      expect(crossSpawn.sync).toHaveBeenCalledWith(
+        'eslint',
+        [
+          '--ignore-path',
+          './packages/ez-scripts/src/files/.eslintignore',
+          '--cache',
+          '.',
+          '--ext',
+          'js,jsx,ts,tsx',
+        ],
+        {stdio: 'inherit'}
+      );
+    });
+  });
+
+  describe('with package.json prop "eslintIgnore"', () => {
+    it('does not use ez-scripts eslint ignore config', () => {
+      const readPkgUp = require('read-pkg-up');
+      const crossSpawn = buildMockCrossSpawn();
+      jest.spyOn(readPkgUp, 'sync').mockReturnValue({
+        packageJson: {
+          dependencies: {},
+          eslintIgnore: ['fake-file.txt'],
+        },
+        path: '/',
+      });
+      executeScript();
+
+      expect(crossSpawn.sync).toHaveBeenCalledTimes(1);
+      expect(crossSpawn.sync).toHaveBeenCalledWith(
+        'eslint',
+        [
+          '--config',
+          './packages/ez-scripts/src/files/eslintrc.js',
+          '--cache',
+          '.',
+          '--ext',
+          'js,jsx,ts,tsx',
+        ],
+        {stdio: 'inherit'}
+      );
+    });
+  });
+
+  describe('with package.json props "eslintConfig" and "eslintIgnore"', () => {
+    it('does not use ez-scripts eslint config or eslint ignore config', () => {
+      const readPkgUp = require('read-pkg-up');
+      const crossSpawn = buildMockCrossSpawn();
+      jest.spyOn(readPkgUp, 'sync').mockReturnValue({
+        packageJson: {
+          dependencies: {},
+          eslintConfig: {'no-console': 'off'},
+          eslintIgnore: ['fake-file.txt'],
+        },
+        path: '/',
+      });
+      executeScript();
+
+      expect(crossSpawn.sync).toHaveBeenCalledTimes(1);
+      expect(crossSpawn.sync).toHaveBeenCalledWith(
+        'eslint',
+        ['--cache', '.', '--ext', 'js,jsx,ts,tsx'],
+        {stdio: 'inherit'}
+      );
+    });
+  });
+});

--- a/packages/ez-scripts/src/utils.js
+++ b/packages/ez-scripts/src/utils.js
@@ -1,11 +1,11 @@
+// @ts-check
 const fs = require('fs');
 const path = require('path');
-const has = require('lodash.has');
 const readPkgUp = require('read-pkg-up');
 const which = require('which');
 const spawn = require('cross-spawn');
 
-const {pkg, path: pkgPath} = readPkgUp.sync({
+const {packageJson: pkg, path: pkgPath} = readPkgUp.sync({
   cwd: fs.realpathSync(process.cwd()),
 });
 const appDirectory = path.dirname(pkgPath);
@@ -34,7 +34,9 @@ function resolveBin(modName, {executable = modName, cwd = process.cwd()} = {}) {
 const fromRoot = (...p) => path.join(appDirectory, ...p);
 const hasFile = (...p) => fs.existsSync(fromRoot(...p));
 
-const hasPkgProp = props => Array.from(props).some(prop => has(pkg, prop));
+function hasPkgProp(prop) {
+  return !!pkg[prop];
+}
 
 function getBufferContent(chunks) {
   return Buffer.isBuffer(chunks[0]) ? Buffer.concat(chunks).toString('utf8') : null;
@@ -58,9 +60,8 @@ function asyncSpawn(cmd, args, options) {
 
     child.on('close', code => {
       if (code !== 0) {
-        // eslint-disable-next-line no-console
         const err = new Error(`${cmd} exited with an error (code ${code}).`);
-        err.log = getBufferContent(stdout);
+        Object.defineProperty(err, 'log', {value: getBufferContent(stdout)});
         reject(err);
         return;
       }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4860,11 +4860,6 @@ lodash.camelcase@4.3.0:
   resolved "https://ezcater.jfrog.io/ezcater/api/npm/npm/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz#b28aa6288a2b9fc651035c7711f65ab6190331a6"
   integrity sha1-soqmKIorn8ZRA1x3EfZathkDMaY=
 
-lodash.has@^4.5.2:
-  version "4.5.2"
-  resolved "https://ezcater.jfrog.io/ezcater/api/npm/npm/lodash.has/-/lodash.has-4.5.2.tgz#d19f4dc1095058cccbe2b0cdf4ee0fe4aa37c862"
-  integrity sha1-0Z9NwQlQWMzL4rDN9O4P5Ko3yGI=
-
 lodash.ismatch@^4.4.0:
   version "4.4.0"
   resolved "https://ezcater.jfrog.io/ezcater/api/npm/npm/lodash.ismatch/-/lodash.ismatch-4.4.0.tgz#756cb5150ca3ba6f11085a78849645f188f85f37"


### PR DESCRIPTION
## What did we change?

The package.json property `eslintConfig` and `eslintIgnore` are not read by the `ez-scripts lint` command.

## Why are we doing this?

Bugfix