### PR TITLE
build: add publishConfig

### DIFF
--- a/packages/eslint-config-ezcater-base/package.json
+++ b/packages/eslint-config-ezcater-base/package.json
@@ -21,6 +21,10 @@
   ],
   "author": "ezCater",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org"
+  },
   "dependencies": {
     "eslint-config-airbnb-base": "^14.2.1",
     "eslint-config-prettier": "^6.15.0",

--- a/packages/eslint-config-ezcater-react/package.json
+++ b/packages/eslint-config-ezcater-react/package.json
@@ -21,6 +21,10 @@
   ],
   "author": "ezCater",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org"
+  },
   "dependencies": {
     "@babel/core": "^7.12.3",
     "@babel/eslint-parser": "^7.12.1",

--- a/packages/eslint-config-ezcater-typescript/package.json
+++ b/packages/eslint-config-ezcater-typescript/package.json
@@ -21,6 +21,10 @@
   ],
   "author": "ezCater",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org"
+  },
   "dependencies": {
     "@typescript-eslint/eslint-plugin": "^2.34.0",
     "@typescript-eslint/parser": "^2.34.0",

--- a/packages/ez-scripts/package.json
+++ b/packages/ez-scripts/package.json
@@ -15,6 +15,10 @@
   },
   "author": "ezCater",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org"
+  },
   "dependencies": {
     "@ezcater/prettier-config": "^1.0.1",
     "cross-spawn": "^7.0.0",

--- a/packages/prettier-config/package.json
+++ b/packages/prettier-config/package.json
@@ -8,5 +8,9 @@
     "directory": "packages/prettier-config"
   },
   "license": "MIT",
-  "main": "index.json"
+  "main": "index.json",
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org"
+  }
 }


### PR DESCRIPTION
## What did we change?

Add default npm publishConfig

## Why are we doing this?

We had prior issues with only publishing to private artifactory instead of npm. This just ensures we always publish to npm with public access.