### PR TITLE
fix: make typescript a peer dep

### DIFF
--- a/packages/eslint-config-ezcater-typescript/CHANGELOG.md
+++ b/packages/eslint-config-ezcater-typescript/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+### Fix
+- Make `typescript` a peer dependency instead of dependency

--- a/packages/eslint-config-ezcater-typescript/package.json
+++ b/packages/eslint-config-ezcater-typescript/package.json
@@ -29,10 +29,10 @@
     "@typescript-eslint/eslint-plugin": "^2.34.0",
     "@typescript-eslint/parser": "^2.34.0",
     "eslint-config-ezcater-react": "^4.0.1",
-    "eslint-import-resolver-typescript": "^1.1.1",
-    "typescript": "^4.0.5"
+    "eslint-import-resolver-typescript": "^1.1.1"
   },
   "peerDependencies": {
-    "eslint": "^7.13.0"
+    "eslint": "^7.13.0",
+    "typescript": ">=4.0.5"
   }
 }


### PR DESCRIPTION
## What did we change?

Make typescript a peer dependency instead of being exposed as a dependency.

## Why are we doing this?

`typescript` should be a peer dependency so consumers don't have multiple versions of typescript used.