### PR TITLE
fix: loosen base config peer dep to allow eslint@8

### DIFF
--- a/packages/eslint-config-ezcater-base/CHANGELOG.md
+++ b/packages/eslint-config-ezcater-base/CHANGELOG.md
@@ -6,5 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- fix: allow eslint v8 as peer dependency
+
 ### Breaking changes
 - Drop support for `eslint-plugin-prettier`, which is no longer recommended by Prettier. This is a breaking change because if consumers have any code comments including `prettier/prettier` eslint will now fail. Consumers are now expected to run `prettier --check` in CI if they want to keep the code quality validation. It's recommended to use `prettier --write` in lint-staged if you want to auto-format code and or use VSCode Prettier extension.

--- a/packages/eslint-config-ezcater-base/CHANGELOG.md
+++ b/packages/eslint-config-ezcater-base/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 - fix: allow eslint v8 as peer dependency
+- fix: remove prettier as a peer dependency
 
 ### Breaking changes
 - Drop support for `eslint-plugin-prettier`, which is no longer recommended by Prettier. This is a breaking change because if consumers have any code comments including `prettier/prettier` eslint will now fail. Consumers are now expected to run `prettier --check` in CI if they want to keep the code quality validation. It's recommended to use `prettier --write` in lint-staged if you want to auto-format code and or use VSCode Prettier extension.

--- a/packages/eslint-config-ezcater-base/package.json
+++ b/packages/eslint-config-ezcater-base/package.json
@@ -32,7 +32,6 @@
     "eslint-plugin-jsx-a11y": "^6.4.1"
   },
   "peerDependencies": {
-    "eslint": ">=7.13.0",
-    "prettier": "^2.1.2"
+    "eslint": ">=7.13.0"
   }
 }

--- a/packages/eslint-config-ezcater-base/package.json
+++ b/packages/eslint-config-ezcater-base/package.json
@@ -32,7 +32,7 @@
     "eslint-plugin-jsx-a11y": "^6.4.1"
   },
   "peerDependencies": {
-    "eslint": "^7.13.0",
+    "eslint": ">=7.13.0",
     "prettier": "^2.1.2"
   }
 }


### PR DESCRIPTION
## What did we change?

These changes are all for the `eslint-config-ezcater-base` package.

- Loosen peer dependency for eslint
- Remove prettier as a peer dependency

## Why are we doing this?

This is mostly preparing for eslint v8. Having the eslint peer dependency loose like this is mentioned in the eslint docs: https://eslint.org/docs/developer-guide/shareable-configs#publishing-a-shareable-config

> You should declare your dependency on ESLint in package.json using the [peerDependencies](https://docs.npmjs.com/files/package.json#peerdependencies) field. The recommended way to declare a dependency for future proof compatibility is with the ">=" range syntax, using the lowest required ESLint version.

Prettier wasn't necessary as a peer dependency, it's not required by `eslint-config-prettier`. If an app doesn't have prettier there's no warnings, it's just ignored.