### PR TITLE
refactor!: require eslint-plugin-import as peer dep

### DIFF
--- a/packages/eslint-config-ezcater-base/CHANGELOG.md
+++ b/packages/eslint-config-ezcater-base/CHANGELOG.md
@@ -8,3 +8,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Breaking changes
 - Drop support for `eslint-plugin-prettier`, which is no longer recommended by Prettier. This is a breaking change because if consumers have any code comments including `prettier/prettier` eslint will now fail. Consumers are now expected to run `prettier --check` in CI if they want to keep the code quality validation. It's recommended to use `prettier --write` in lint-staged if you want to auto-format code and or use VSCode Prettier extension.
+- Change `eslint-plugin-import` to be a peer dependency rather than exposed a dependency of the config. This will require consumers to add `eslint-plugin-import` to their dev dependencies.

--- a/packages/eslint-config-ezcater-base/package.json
+++ b/packages/eslint-config-ezcater-base/package.json
@@ -28,11 +28,10 @@
   "dependencies": {
     "eslint-config-airbnb-base": "^14.2.1",
     "eslint-config-prettier": "^8.5.0",
-    "eslint-plugin-import": "^2.22.1",
     "eslint-plugin-jsx-a11y": "^6.4.1"
   },
   "peerDependencies": {
     "eslint": "^7.13.0",
-    "prettier": "^2.1.2"
+    "eslint-plugin-import": ">=2.22.1"
   }
 }


### PR DESCRIPTION
## What did we change?

Move [eslint-plugin-import](https://github.com/import-js/eslint-plugin-import) from a dependency to a peer dependency.

This is a breaking change because consumers will have to add `eslint-plugin-import` as a dev dependency.

## Why are we doing this?

`eslint-config-airbnb-base`, which we use, has `eslint-plugin-import` as a peer dependency, which makes us add it.  The [eslint docs mention](https://eslint.org/docs/developer-guide/shareable-configs#publishing-a-shareable-config) as a good practice that shareable configs should add plugins as peer dependencies though:

> If your shareable config depends on a plugin, you should also specify it as a peerDependency (plugins will be loaded relative to the end user's project, so the end user is required to install the plugins they need). However, if your shareable config depends on a third-party parser or another shareable config, you can specify these packages as dependencies.

I believe it make sense to let the consumer handle this dependency so this config doesn't have to keep up with the updates of it. Internally a lot of ezCater's apps include `eslint-plugin-import` as a dev dependency anyways.