### PR TITLE
fix: remove unused dep eslint-plugin-jsx-a11y

### DIFF
--- a/packages/eslint-config-ezcater-base/CHANGELOG.md
+++ b/packages/eslint-config-ezcater-base/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 - fix: allow eslint v8 as peer dependency
 - fix: remove prettier as a peer dependency
+- fix: remove unused dep eslint-plugin-jsx-a11y
 
 ### Breaking changes
 - Drop support for `eslint-plugin-prettier`, which is no longer recommended by Prettier. This is a breaking change because if consumers have any code comments including `prettier/prettier` eslint will now fail. Consumers are now expected to run `prettier --check` in CI if they want to keep the code quality validation. It's recommended to use `prettier --write` in lint-staged if you want to auto-format code and or use VSCode Prettier extension.

--- a/packages/eslint-config-ezcater-base/package.json
+++ b/packages/eslint-config-ezcater-base/package.json
@@ -28,8 +28,7 @@
   "dependencies": {
     "eslint-config-airbnb-base": "^14.2.1",
     "eslint-config-prettier": "^8.5.0",
-    "eslint-plugin-import": "^2.22.1",
-    "eslint-plugin-jsx-a11y": "^6.4.1"
+    "eslint-plugin-import": "^2.22.1"
   },
   "peerDependencies": {
     "eslint": ">=7.13.0"


### PR DESCRIPTION
## What did we change?

Remove dependency `eslint-plugin-jsx-a11y` from `eslint-config-ezcater-base` package. I think 

## Why are we doing this?

I think this was added as a dependency originally because `eslint-config-airbnb-base` used to require it before the package split off to `eslint-config-airbnb`.