### PR TITLE
fix: loosen react config peer dep to allow eslint@8

### DIFF
--- a/packages/eslint-config-ezcater-react/CHANGELOG.md
+++ b/packages/eslint-config-ezcater-react/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+- fix: allow eslint v8 as peer dependency

--- a/packages/eslint-config-ezcater-react/package.json
+++ b/packages/eslint-config-ezcater-react/package.json
@@ -39,6 +39,6 @@
     "eslint-plugin-react-hooks": "^2.5.1"
   },
   "peerDependencies": {
-    "eslint": "^7.13.0"
+    "eslint": ">=7.13.0"
   }
 }


### PR DESCRIPTION
## What did we change?

Loosen eslint peer dependency for `eslint-config-ezcater-react` package.

## Why are we doing this?

This is mostly preparing for eslint v8. Having the eslint peer dependency loose like this is mentioned in the eslint docs: https://eslint.org/docs/developer-guide/shareable-configs#publishing-a-shareable-config

> You should declare your dependency on ESLint in package.json using the [peerDependencies](https://docs.npmjs.com/files/package.json#peerdependencies) field. The recommended way to declare a dependency for future proof compatibility is with the ">=" range syntax, using the lowest required ESLint version.
