### PR TITLE
fix: detect react version instead of fixed version [react]

### DIFF
--- a/packages/eslint-config-ezcater-react/CHANGELOG.md
+++ b/packages/eslint-config-ezcater-react/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 - fix: allow eslint v8 as peer dependency
+- fix: "detect" react version instead of fixed version
 
 ### Breaking changes
 - Upgrade to `eslint-config-ezcater-base@5` which drops support for `eslint-plugin-prettier`. This is a breaking change because if consumers have any code comments including `prettier/prettier` eslint will now fail. Consumers are now expected to run `prettier --check` in CI if they want to keep the code quality validation. It's recommended to use `prettier --write` in lint-staged if you want to auto-format code and or use VSCode Prettier extension.

--- a/packages/eslint-config-ezcater-react/rules/react.js
+++ b/packages/eslint-config-ezcater-react/rules/react.js
@@ -24,7 +24,7 @@ module.exports = {
   },
   settings: {
     react: {
-      version: '16.0',
+      version: 'detect',
     },
   },
 };


### PR DESCRIPTION
## What did we change?

Change settings for react version from `16.0` to `detect`

## Why are we doing this?

From [eslint-plugin-react docs](https://github.com/yannickcr/eslint-plugin-react#configuration):

> "detect" automatically picks the version you have installed.
> You can also use `16.0`, `16.3`, etc, if you want to override the detected value.