### PR TITLE
fix: copy prev rules from eslint-plugin-prettier

### DIFF
--- a/packages/eslint-config-ezcater-base/CHANGELOG.md
+++ b/packages/eslint-config-ezcater-base/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+- fix: disable rules `arrow-body-style` and `prefer-arrow-callback` to copy previous behavior from `eslint-plugin-prettier`
+
 ## [5.0.0] - 2022-03-30
 - fix: allow eslint v8 as peer dependency
 - fix: remove prettier as a peer dependency

--- a/packages/eslint-config-ezcater-base/rules/base.js
+++ b/packages/eslint-config-ezcater-base/rules/base.js
@@ -1,5 +1,6 @@
 module.exports = {
   rules: {
+    'arrow-body-style': 'off', // Copying behavior of eslint-plugin-prettier
     eqeqeq: ['error', 'smart'],
     'linebreak-style': 'off',
     'no-use-before-define': 'off',
@@ -7,6 +8,7 @@ module.exports = {
     'no-console': 'error',
     'no-extra-bind': 'error',
     'no-implicit-globals': 'error',
+    'prefer-arrow-callback': 'off', // Copying behavior of eslint-plugin-prettier
     'prefer-promise-reject-errors': 'error',
     curly: ['error', 'multi-or-nest'],
     'object-curly-spacing': ['error', 'never'],


### PR DESCRIPTION
## What did we change?

Disable rules `arrow-body-style` and `prefer-arrow-callback` to copy previous behavior from `eslint-plugin-prettier`.

## Why are we doing this?

With PR #6 `eslint-plugin-prettier` was dropped as a dependency. `eslint-plugin-prettier` turns off the rules: `arrow-body-style`, `prefer-arrow-callback`.

`arrow-body-style` is a rule that will cause a lot of conflicts in existing builds. `prefer-arrow-callback` is less likely to cause issues, but it's being turned off just because that was existing behavior when we had `eslint-plugin-prettier`.