### PR TITLE
refactor!: replace react config with base config [typescript]

### DIFF
--- a/packages/eslint-config-ezcater-typescript/CHANGELOG.md
+++ b/packages/eslint-config-ezcater-typescript/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 - fix: allow eslint v8 as peer dependency
+- feat: only extend typescript rules to .ts/.tsx files
 
 ### Breaking changes
 - Replaced `eslint-config-ezcater-react` with `eslint-config-ezcater-base`. Consumers are expected to add `eslint-config-ezcater-react` separately if react linter rules are necessary.

--- a/packages/eslint-config-ezcater-typescript/CHANGELOG.md
+++ b/packages/eslint-config-ezcater-typescript/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- fix: allow eslint v8 as peer dependency
+
 ### Breaking changes
 - Replaced `eslint-config-ezcater-react` with `eslint-config-ezcater-base`. Consumers are expected to add `eslint-config-ezcater-react` separately if react linter rules are necessary.
 - Drop support for `eslint-plugin-prettier`, which is no longer recommended by Prettier. This is a breaking change because if consumers have any code comments including `prettier/prettier` eslint will now fail. Consumers are now expected to run `prettier --check` in CI if they want to keep the code quality validation. It's recommended to use `prettier --write` in lint-staged if you want to auto-format code and or use VSCode Prettier extension.

--- a/packages/eslint-config-ezcater-typescript/CHANGELOG.md
+++ b/packages/eslint-config-ezcater-typescript/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Breaking changes
+- Replaced `eslint-config-ezcater-react` with `eslint-config-ezcater-base`. Consumers are expected to add `eslint-config-ezcater-react` separately if react linter rules are necessary.
+- Drop support for `eslint-plugin-prettier`, which is no longer recommended by Prettier. This is a breaking change because if consumers have any code comments including `prettier/prettier` eslint will now fail. Consumers are now expected to run `prettier --check` in CI if they want to keep the code quality validation. It's recommended to use `prettier --write` in lint-staged if you want to auto-format code and or use VSCode Prettier extension.
+
 ## [4.0.1] - 2022-03-28
 ### Fix
 - Make `typescript` a peer dependency instead of dependency

--- a/packages/eslint-config-ezcater-typescript/README.md
+++ b/packages/eslint-config-ezcater-typescript/README.md
@@ -2,18 +2,31 @@
 
 [![npm version](https://badge.fury.io/js/eslint-config-ezcater-typescript.svg)](https://badge.fury.io/js/eslint-config-ezcater-typescript)
 
-## Usage
+## Plugins and extensions
 
-Package extends [our base ESLint rules](https://www.npmjs.com/package/eslint-config-ezcater-base), and [our React rules](https://www.npmjs.com/package/eslint-config-ezcater-react) and includes rules for TypeScript.
+This includes the following plugins and extensions:
+
+- [@typescript-eslint/eslint-plugin](https://github.com/typescript-eslint/typescript-eslint/tree/main/packages/eslint-plugin)
+- [@typescript-eslint/parser](https://github.com/typescript-eslint/typescript-eslint/tree/main/packages/parser)
+- [eslint-config-ezcater-base](https://github.com/ezcater/ezcater-js-toolkit/tree/main/packages/eslint-config-ezcater-base)
+- [eslint-import-resolver-typescript](https://github.com/alexgorbatchev/eslint-import-resolver-typescript)
+
+## Usage
 
 1.  Install the package as a dev dependency for your project:
 
 ```sh
+# NPM
 npm i eslint-config-ezcater-typescript --save-dev
+
+# Yarn
+yarn add eslint-config-ezcater-typescript -D
 ```
 
 2.  Add `ezcater-typescript` to the `extends` section of your project's `.eslintrc`:
 
 ```json
-extends: ['ezcater-typescript'],
+{
+  "extends": ["ezcater-typescript"]
+}
 ```

--- a/packages/eslint-config-ezcater-typescript/index.js
+++ b/packages/eslint-config-ezcater-typescript/index.js
@@ -1,15 +1,21 @@
 module.exports = {
-  parser: '@typescript-eslint/parser',
   plugins: ['@typescript-eslint'],
-  extends: [
-    'plugin:@typescript-eslint/recommended',
-    './rules/typescript.js',
-  ],
-  settings: {
-    parser: 'typescript-eslint-parser',
-    plugins: ['import'],
-    'import/resolver': {
-      typescript: {},
+  overrides: [
+    {
+      files: ['**/*.ts?(x)'],
+      parser: '@typescript-eslint/parser',
+      extends: [
+        'plugin:@typescript-eslint/recommended',
+        './rules/typescript.js',
+      ],
+      settings: {
+        'import/parsers': {
+          '@typescript-eslint/parser': ['.ts', '.tsx'],
+        },
+        'import/resolver': {
+          typescript: {},
+        },
+      },
     },
-  },
+  ],
 };

--- a/packages/eslint-config-ezcater-typescript/index.js
+++ b/packages/eslint-config-ezcater-typescript/index.js
@@ -2,7 +2,6 @@ module.exports = {
   parser: '@typescript-eslint/parser',
   plugins: ['@typescript-eslint'],
   extends: [
-    require.resolve('eslint-config-ezcater-react'),
     'plugin:@typescript-eslint/recommended',
     './rules/typescript.js',
   ],

--- a/packages/eslint-config-ezcater-typescript/package.json
+++ b/packages/eslint-config-ezcater-typescript/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "@typescript-eslint/eslint-plugin": "^2.34.0",
     "@typescript-eslint/parser": "^2.34.0",
-    "eslint-config-ezcater-react": "^4.0.1",
+    "eslint-config-ezcater-base": "^5.0.1",
     "eslint-import-resolver-typescript": "^1.1.1"
   },
   "peerDependencies": {

--- a/packages/eslint-config-ezcater-typescript/package.json
+++ b/packages/eslint-config-ezcater-typescript/package.json
@@ -32,7 +32,7 @@
     "eslint-import-resolver-typescript": "^1.1.1"
   },
   "peerDependencies": {
-    "eslint": "^7.13.0",
+    "eslint": ">=7.13.0",
     "typescript": ">=4.0.5"
   }
 }


### PR DESCRIPTION
## What did we change?

Changes to the `eslint-config-ezcater-typescript` package:

- Notable change: Replace `eslint-config-ezcater-react` with `eslint-config-ezcater-base` as a dependency from `eslint-config-ezcater-typescript`.
- Only extend typescript rules to .ts/.tsx files
- Loosen eslint peer dependency to allow for v8.

## Why are we doing this?

The change of removing `eslint-config-ezcater-react` as a dependency of `eslint-config-ezcater-typescript` has two big benefits:
- The publishing strategy for `eslint-config-ezcater-typescript` is easier. Currently, if we were to change `eslint-config-ezcater-base` it would require updating `eslint-config-ezcater-react` and publishing the new release, then updating `eslint-config-ezcater-typescript`.
- Not all typescript projects are expected to use react. Separating the react rules makes more sense here.