### PR TITLE
fix: add missing base config to ts config [typescript]

### DIFF
--- a/packages/eslint-config-ezcater-typescript/CHANGELOG.md
+++ b/packages/eslint-config-ezcater-typescript/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- fix: extend `eslint-config-ezcater-base` from config
 
 ## [5.0.0] - 2022-04-25
 - fix: allow eslint v8 as peer dependency

--- a/packages/eslint-config-ezcater-typescript/index.js
+++ b/packages/eslint-config-ezcater-typescript/index.js
@@ -5,6 +5,7 @@ module.exports = {
       files: ['**/*.ts?(x)'],
       parser: '@typescript-eslint/parser',
       extends: [
+        require.resolve('eslint-config-ezcater-base'),
         'plugin:@typescript-eslint/recommended',
         './rules/typescript.js',
       ],


### PR DESCRIPTION
## What did we change?

Extend `eslint-config-ezcater-base` from `eslint-config-ezcater-typescript`

## Why are we doing this?

This was meant to be included in `eslint-config-ezcater-typescript@5` release, but it was missed. The repos I tested with were react ones which already extends the base config, so the issue didn't come up.