### PR TITLE
build!: move plugins to peer deps for react config

### DIFF
--- a/packages/eslint-config-ezcater-react/CHANGELOG.md
+++ b/packages/eslint-config-ezcater-react/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Breaking changes
+- Bump `esling-config-ezcater-base` from 5.0.1 to 6.0.0, which has the breaking change of requiring `eslint-plugin-import` as a peer dependency.
+- Move: `eslint-plugin-filenames`, `eslint-plugin-import`, `eslint-plugin-jest`, `eslint-plugin-jsx-a11y`, `eslint-plugin-react`, `eslint-plugin-react-hooks` from dependencies to requiring as peer dependencies. This is to follow eslint best practices for shareable configs mentioned [here](https://eslint.org/docs/latest/extend/shareable-configs#publishing-a-shareable-config).
 
 ## [5.0.0] - 2022-04-14
 - fix: allow eslint v8 as peer dependency

--- a/packages/eslint-config-ezcater-react/package.json
+++ b/packages/eslint-config-ezcater-react/package.json
@@ -27,15 +27,15 @@
   },
   "dependencies": {
     "eslint-config-airbnb": "^18.2.1",
-    "eslint-config-ezcater-base": "^5.0.1",
-    "eslint-plugin-filenames": "^1.3.2",
-    "eslint-plugin-import": "^2.22.1",
-    "eslint-plugin-jest": "^22.21.0",
-    "eslint-plugin-jsx-a11y": "^6.4.1",
-    "eslint-plugin-react": "^7.21.5",
-    "eslint-plugin-react-hooks": "^2.5.1"
+    "eslint-config-ezcater-base": "^6.0.0"
   },
   "peerDependencies": {
-    "eslint": ">=7.13.0"
+    "eslint": ">=7.13.0",
+    "eslint-plugin-filenames": ">=1.3.2",
+    "eslint-plugin-import": ">=2.25.3",
+    "eslint-plugin-jest": ">=22.21.0",
+    "eslint-plugin-jsx-a11y": ">=6.5.1",
+    "eslint-plugin-react": ">=7.27.0",
+    "eslint-plugin-react-hooks": ">=4.3.0"
   }
 }


### PR DESCRIPTION
## What did we change?
Move the following dependencies to peer dependencies:
- `eslint-plugin-import`
- `eslint-plugin-filenames`
- `eslint-plugin-jest`
- `eslint-plugin-jsx-a11y`
- `eslint-plugin-react`
- `eslint-plugin-react-hooks`

Also, bump any of the peer dependencies of `eslint-config-airbnb` to the minimum version it requires.

## Why are we doing this?
This is following eslint's best practices for shareable configs mentioned [here](https://eslint.org/docs/latest/extend/shareable-configs#publishing-a-shareable-config).
> If your shareable config depends on a plugin, you should also specify it as a peerDependency (plugins will be loaded relative to the end user’s project, so the end user is required to install the plugins they need). However, if your shareable config depends on a third-party parser or another shareable config, you can specify these packages as dependencies.